### PR TITLE
Fix new dead code warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ mod tests {
         }}
     }
 
+    #[allow(dead_code)]
     trait Trait {
         fn blah(&self);
     }


### PR DESCRIPTION
This warning appeared recently:

```
   Compiling cfg-if v1.0.0 (/home/runner/work/rustc_codegen_gcc/rustc_codegen_gcc/projects/cfg-if)
    Finished release [optimized] target(s) in 0.12s
   Compiling cfg-if v1.0.0 (/home/runner/work/rustc_codegen_gcc/rustc_codegen_gcc/projects/cfg-if)
error: trait `Trait` is never used
   --> src/lib.rs:169:11
    |
169 |     trait Trait {
    |           ^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:29:24
    |
29  | #![cfg_attr(test, deny(warnings))]
    |                        ^^^^^^^^
    = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`

error: could not compile `cfg-if` (lib test) due to 1 previous error
```