### PR TITLE
Disable the `unexpected_cfgs` lint when testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![doc(html_root_url = "https://docs.rs/cfg-if")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
+#![cfg_attr(test, allow(unexpected_cfgs))] // we test with features that do not exist
 
 /// The main macro provided by this crate. See crate documentation for more
 /// information.

--- a/tests/xcrate.rs
+++ b/tests/xcrate.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)] // `foo` doesn't exist
+
 cfg_if::cfg_if! {
     if #[cfg(foo)] {
         fn works() -> bool { false }


### PR DESCRIPTION
We test using config options that do not exist, so this lint is not helpful. Disable it when testing because it causes CI failures.