### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ item that gets emitted.
 edition = "2018"
 
 [dependencies]
-core = { version = "1.0.0", optional = true, package = 'rustc-std-workspace-core' }
-compiler_builtins = { version = '0.1.2', optional = true }
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 
 [features]
-rustc-dep-of-std = ['core', 'compiler_builtins']
+rustc-dep-of-std = ["core"]


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993